### PR TITLE
docs: fixed URL to MCP demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ volumes:
 
 # See Also
 
-- [MCP UI App Demo](https://github.com/pomerium/mcp-demo/app): A Node.js/React UI app demonstrating how to build a simple application that calls the OpenAI API with MCP server support.
+- [MCP UI App Demo](https://github.com/pomerium/mcp-app-demo): A Node.js/React UI app demonstrating how to build a simple application that calls the OpenAI API with MCP server support.
 - [Support Forum](https://discuss.pomerium.com/)
 - [Pomerium Docs](https://www.pomerium.com/docs)
 


### PR DESCRIPTION
The URL to the MCP demo app was 404ing. I updated it to the correct URL.