### PR TITLE
refactor: restructure CLI to support subcommands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ WORKDIR /go
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /bin/server ./cmd/main.go
+RUN go build -o /bin/server ./cmd/
 
 FROM gcr.io/distroless/base-debian12@sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44
-ENV PORT=8080
 COPY --from=build /bin/server /bin/server
 ENTRYPOINT ["/bin/server"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,25 +2,45 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
-
-	"github.com/pomerium/mcp-servers/httputil"
-	"github.com/pomerium/mcp-servers/server"
+	"path/filepath"
 )
 
+var programName = filepath.Base(os.Args[0])
+
 func main() {
-	err := run(context.Background())
-	if err != nil {
-		log.Fatal(err)
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context) error {
-	port, ok := os.LookupEnv("PORT")
-	if !ok {
-		port = "8080"
+func run(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return printUsage()
 	}
-	handler := server.BuildHandlers(ctx)
-	return httputil.ListenAndServe(ctx, ":"+port, handler)
+
+	cmd, cmdArgs := args[0], args[1:]
+
+	switch cmd {
+	case "serve":
+		return serveCommand(ctx, cmdArgs)
+	case "help", "-h", "--help":
+		return printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
+		return printUsage()
+	}
+}
+
+func printUsage() error {
+	fmt.Fprintf(os.Stderr, `Usage: %s <command> [options]
+
+Commands:
+  serve    Start the MCP server
+
+Use "%s <command> -h" for more information about a command.
+`, programName, programName)
+	return nil
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/pomerium/mcp-servers/httputil"
+	"github.com/pomerium/mcp-servers/server"
+)
+
+func serveCommand(ctx context.Context, _ []string) error {
+	addr := os.Getenv("ADDR")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	handler := server.BuildHandlers(ctx)
+	return httputil.ListenAndServe(ctx, addr, handler)
+}


### PR DESCRIPTION
## Summary
- Move server logic under a `serve` subcommand to enable adding more commands with different parameters
- Use `ADDR` env var for configuration following 12-factor app principles
- Update Dockerfile to build from `./cmd/` directory

## Test plan
- [ ] Run `go build ./cmd/` to verify compilation
- [ ] Test `./server serve` starts on default port :8080
- [ ] Test `ADDR=:3000 ./server serve` uses custom port
- [ ] Test `./server help` shows usage
- [ ] Verify Docker build works