### PR TITLE
feat: add stdio-proxy command for HTTP-to-stdio MCP bridging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ func run(ctx context.Context, args []string) error {
 	switch cmd {
 	case "serve":
 		return serveCommand(ctx, cmdArgs)
+	case "stdio-proxy":
+		return stdioProxyCommand(ctx, cmdArgs)
 	case "help", "-h", "--help":
 		return printUsage()
 	default:
@@ -38,7 +40,8 @@ func printUsage() error {
 	fmt.Fprintf(os.Stderr, `Usage: %s <command> [options]
 
 Commands:
-  serve    Start the MCP server
+  serve         Start the MCP server
+  stdio-proxy   Proxy HTTP requests to a stdio MCP server
 
 Use "%s <command> -h" for more information about a command.
 `, programName, programName)

--- a/cmd/stdio_proxy.go
+++ b/cmd/stdio_proxy.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/pomerium/mcp-servers/httputil"
+	"github.com/pomerium/mcp-servers/stdioproxy"
+)
+
+func stdioProxyCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("stdio-proxy", flag.ExitOnError)
+
+	addr := fs.String("addr", "", "HTTP bind address (default from ADDR env or :8080)")
+	logLevel := fs.String("log-level", "", "Log level: debug, info, warn, error (default from LOG_LEVEL env or info)")
+	workDir := fs.String("work-dir", "", "Working directory for subprocess")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: %s stdio-proxy [options] -- <command> [args...]
+
+Proxy HTTP streaming requests to a stdio MCP server.
+
+Options:
+`, programName)
+		fs.PrintDefaults()
+		fmt.Fprintf(os.Stderr, `
+Environment variables:
+  ADDR       HTTP bind address (default :8080)
+  LOG_LEVEL  Log level: debug, info, warn, error (default info)
+
+Examples:
+  # Proxy requests to a Node.js MCP server
+  %s stdio-proxy -- node /path/to/server.js
+
+  # Proxy with custom port and debug logging
+  %s stdio-proxy -addr :9090 -log-level debug -- python -m my_mcp_server
+
+  # Using environment variables
+  ADDR=:9090 LOG_LEVEL=debug %s stdio-proxy -- ./my-server
+`, programName, programName, programName)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Remaining args are the subprocess command
+	subArgs := fs.Args()
+	if len(subArgs) == 0 {
+		fs.Usage()
+		return fmt.Errorf("missing subprocess command")
+	}
+
+	// Resolve bind address
+	bindAddr := *addr
+	if bindAddr == "" {
+		bindAddr = os.Getenv("ADDR")
+	}
+	if bindAddr == "" {
+		bindAddr = ":8080"
+	}
+
+	// Resolve log level
+	level := *logLevel
+	if level == "" {
+		level = os.Getenv("LOG_LEVEL")
+	}
+	if level == "" {
+		level = "info"
+	}
+
+	// Setup logger (JSON for daemon, text for terminal)
+	logger := stdioproxy.SetupLogger(stdioproxy.ParseLogLevel(level))
+	slog.SetDefault(logger)
+
+	logger.Info("starting stdio-proxy",
+		"addr", bindAddr,
+		"command", subArgs[0],
+		"args", subArgs[1:],
+	)
+
+	// Create process manager
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Command: subArgs[0],
+		Args:    subArgs[1:],
+		WorkDir: *workDir,
+		Logger:  logger,
+	})
+
+	// Start the subprocess
+	if err := pm.Start(ctx); err != nil {
+		return fmt.Errorf("start subprocess: %w", err)
+	}
+
+	// Ensure cleanup on shutdown
+	defer func() {
+		if err := pm.Stop(); err != nil {
+			logger.Warn("error stopping subprocess", "error", err)
+		}
+	}()
+
+	// Create proxy server
+	proxyServer := stdioproxy.NewProxyServer(pm, logger)
+
+	// Create HTTP handler
+	handler, err := stdioproxy.NewHTTPHandler(pm, proxyServer, logger)
+	if err != nil {
+		return fmt.Errorf("create HTTP handler: %w", err)
+	}
+
+	// Start HTTP server (blocks until context is cancelled)
+	return httputil.ListenAndServe(ctx, bindAddr, handler)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.24.2
 
 require (
 	github.com/jomei/notionapi v1.13.3
-	github.com/modelcontextprotocol/go-sdk v1.1.0
+	github.com/mattn/go-isatty v0.0.20
+	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/pomerium/sdk-go v0.0.9
 	modernc.org/sqlite v1.38.0
 )
@@ -15,7 +16,6 @@ require (
 	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.4 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/stretchr/testify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -20,8 +22,8 @@ github.com/jomei/notionapi v1.13.3 h1:pzEN+pVe1T0FjH85sP9TCqqe58rFRL+Fj+F5yvyBNw
 github.com/jomei/notionapi v1.13.3/go.mod h1:BqzP6JBddpBnXvMSIxiR5dCoCjKngmz5QNl1ONDlDoM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/modelcontextprotocol/go-sdk v1.1.0 h1:Qjayg53dnKC4UZ+792W21e4BpwEZBzwgRW6LrjLWSwA=
-github.com/modelcontextprotocol/go-sdk v1.1.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
+github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/stdioproxy/bidirectional_test.go
+++ b/stdioproxy/bidirectional_test.go
@@ -1,0 +1,467 @@
+package stdioproxy_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/pomerium/mcp-servers/stdioproxy"
+)
+
+// newBidirectionalTestServer creates a test server that supports bidirectional features.
+func newBidirectionalTestServer(t *testing.T) mcp.Transport {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "bidirectional-test-server",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+
+	// Tool that triggers sampling (CreateMessage request to client)
+	type samplingArgs struct {
+		Prompt string `json:"prompt" jsonschema:"The prompt to send"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "request_sampling",
+		Description: "Request LLM sampling from the client",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args samplingArgs) (*mcp.CallToolResult, any, error) {
+		session := req.Session
+		result, err := session.CreateMessage(ctx, &mcp.CreateMessageParams{
+			Messages: []*mcp.SamplingMessage{
+				{
+					Role: "user",
+					Content: &mcp.TextContent{
+						Text: args.Prompt,
+					},
+				},
+			},
+			MaxTokens: 100,
+		})
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "sampling error: " + err.Error()},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		// Extract text from the response
+		text := ""
+		if tc, ok := result.Content.(*mcp.TextContent); ok {
+			text = tc.Text
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "sampling result: " + text},
+			},
+		}, nil, nil
+	})
+
+	// Tool that triggers elicitation (request user input from client)
+	type elicitArgs struct {
+		Message string `json:"message" jsonschema:"Message to show user"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "request_elicitation",
+		Description: "Request user input from the client",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args elicitArgs) (*mcp.CallToolResult, any, error) {
+		session := req.Session
+		result, err := session.Elicit(ctx, &mcp.ElicitParams{
+			Message: args.Message,
+			RequestedSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"answer": map[string]any{
+						"type":        "string",
+						"description": "User's answer",
+					},
+				},
+				"required": []string{"answer"},
+			},
+		})
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "elicitation error: " + err.Error()},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		// Check action
+		if result.Action == "cancel" {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "elicitation cancelled"},
+				},
+			}, nil, nil
+		}
+		// Extract answer from content
+		answer := ""
+		if result.Content != nil {
+			if ans, ok := result.Content["answer"].(string); ok {
+				answer = ans
+			}
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "elicitation result: " + answer},
+			},
+		}, nil, nil
+	})
+
+	// Tool that sends a logging message
+	type logArgs struct {
+		Level   string `json:"level" jsonschema:"Log level (debug, info, warning, error)"`
+		Message string `json:"message" jsonschema:"Log message"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "send_log",
+		Description: "Send a logging message to the client",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args logArgs) (*mcp.CallToolResult, any, error) {
+		session := req.Session
+		err := session.Log(ctx, &mcp.LoggingMessageParams{
+			Level:  mcp.LoggingLevel(args.Level),
+			Logger: "test-server",
+			Data:   args.Message,
+		})
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "logging error: " + err.Error()},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "log sent"},
+			},
+		}, nil, nil
+	})
+
+	// Simple echo tool for basic tests
+	type echoArgs struct {
+		Message string `json:"message"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "echo",
+		Description: "Echo a message",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args echoArgs) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: args.Message},
+			},
+		}, nil, nil
+	})
+
+	// Start server
+	go func() {
+		_ = server.Run(t.Context(), serverTransport)
+	}()
+
+	return clientTransport
+}
+
+func TestLoggingNotification(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var loggingCalled atomic.Int32
+	var loggingMessage string
+	var loggingMu sync.Mutex
+
+	transport := newBidirectionalTestServer(t)
+
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+		LoggingMessageHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+			loggingCalled.Add(1)
+			loggingMu.Lock()
+			if data, ok := req.Params.Data.(string); ok {
+				loggingMessage = data
+			}
+			loggingMu.Unlock()
+		},
+	})
+
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer pm.Stop()
+
+	session, err := pm.GetSession()
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	// Set logging level so server will send logs
+	if err := session.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: "debug"}); err != nil {
+		t.Fatalf("failed to set logging level: %v", err)
+	}
+
+	// Call the send_log tool which triggers a logging notification
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "send_log",
+		Arguments: map[string]any{
+			"level":   "info",
+			"message": "test log message",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %v", result.Content)
+	}
+
+	if loggingCalled.Load() == 0 {
+		t.Error("logging handler was not called")
+	}
+
+	loggingMu.Lock()
+	if loggingMessage != "test log message" {
+		t.Errorf("logging message = %q, want %q", loggingMessage, "test log message")
+	}
+	loggingMu.Unlock()
+}
+
+func TestSamplingHandler(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var samplingCalled atomic.Int32
+	var samplingPrompt string
+	var samplingMu sync.Mutex
+
+	transport := newBidirectionalTestServer(t)
+
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+		CreateMessageHandler: func(_ context.Context, req *mcp.CreateMessageRequest) (*mcp.CreateMessageResult, error) {
+			samplingCalled.Add(1)
+			samplingMu.Lock()
+			// Extract prompt from messages
+			if len(req.Params.Messages) > 0 {
+				if tc, ok := req.Params.Messages[0].Content.(*mcp.TextContent); ok {
+					samplingPrompt = tc.Text
+				}
+			}
+			samplingMu.Unlock()
+
+			// Return a mock response
+			return &mcp.CreateMessageResult{
+				Role:    "assistant",
+				Content: &mcp.TextContent{Text: "mock LLM response"},
+				Model:   "test-model",
+			}, nil
+		},
+	})
+
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer pm.Stop()
+
+	session, err := pm.GetSession()
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	// Call the request_sampling tool which triggers a CreateMessage request
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "request_sampling",
+		Arguments: map[string]any{
+			"prompt": "What is 2+2?",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %v", result.Content)
+	}
+
+	if samplingCalled.Load() == 0 {
+		t.Error("sampling handler was not called")
+	}
+
+	samplingMu.Lock()
+	if samplingPrompt != "What is 2+2?" {
+		t.Errorf("sampling prompt = %q, want %q", samplingPrompt, "What is 2+2?")
+	}
+	samplingMu.Unlock()
+
+	// Verify the response contains our mock response
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in result")
+	}
+	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+		if tc.Text != "sampling result: mock LLM response" {
+			t.Errorf("result text = %q, want %q", tc.Text, "sampling result: mock LLM response")
+		}
+	}
+}
+
+func TestElicitationHandler(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var elicitCalled atomic.Int32
+	var elicitMessage string
+	var elicitMu sync.Mutex
+
+	transport := newBidirectionalTestServer(t)
+
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+		ElicitationHandler: func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+			elicitCalled.Add(1)
+			elicitMu.Lock()
+			elicitMessage = req.Params.Message
+			elicitMu.Unlock()
+
+			// Return a mock user response
+			return &mcp.ElicitResult{
+				Action: "accept",
+				Content: map[string]any{
+					"answer": "user's answer",
+				},
+			}, nil
+		},
+	})
+
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer pm.Stop()
+
+	session, err := pm.GetSession()
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	// Call the request_elicitation tool which triggers an Elicit request
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "request_elicitation",
+		Arguments: map[string]any{
+			"message": "Please provide input",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %v", result.Content)
+	}
+
+	if elicitCalled.Load() == 0 {
+		t.Error("elicitation handler was not called")
+	}
+
+	elicitMu.Lock()
+	if elicitMessage != "Please provide input" {
+		t.Errorf("elicit message = %q, want %q", elicitMessage, "Please provide input")
+	}
+	elicitMu.Unlock()
+
+	// Verify the response contains the user's answer
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in result")
+	}
+	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+		if tc.Text != "elicitation result: user's answer" {
+			t.Errorf("result text = %q, want %q", tc.Text, "elicitation result: user's answer")
+		}
+	}
+}
+
+func TestSamplingWithoutHandler(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	transport := newBidirectionalTestServer(t)
+
+	// Don't set a CreateMessageHandler - should get an error
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+	})
+
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer pm.Stop()
+
+	session, err := pm.GetSession()
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	// Call the request_sampling tool - should fail because no handler
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "request_sampling",
+		Arguments: map[string]any{
+			"prompt": "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+
+	// The tool should return an error because sampling is not supported
+	if !result.IsError {
+		t.Error("expected error when sampling without handler")
+	}
+}
+
+func TestElicitationWithoutHandler(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	transport := newBidirectionalTestServer(t)
+
+	// Don't set an ElicitationHandler - should get an error
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+	})
+
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer pm.Stop()
+
+	session, err := pm.GetSession()
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	// Call the request_elicitation tool - should fail because no handler
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "request_elicitation",
+		Arguments: map[string]any{
+			"message": "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call tool failed: %v", err)
+	}
+
+	// The tool should return an error because elicitation is not supported
+	if !result.IsError {
+		t.Error("expected error when elicitation without handler")
+	}
+}

--- a/stdioproxy/logging.go
+++ b/stdioproxy/logging.go
@@ -1,0 +1,47 @@
+// Package stdioproxy provides a proxy that exposes a stdio MCP server via HTTP streaming.
+package stdioproxy
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// SetupLogger configures slog based on whether we're running in a terminal or as a daemon.
+// Terminal mode uses human-readable text format, daemon mode uses JSON for structured logging.
+func SetupLogger(level slog.Level) *slog.Logger {
+	var handler slog.Handler
+
+	// Detect if stderr is a terminal (we log to stderr to keep stdout clean)
+	if isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()) {
+		// Human-readable format for terminal
+		handler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: level,
+		})
+	} else {
+		// JSON format for daemon/log aggregation
+		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+			Level: level,
+		})
+	}
+
+	return slog.New(handler)
+}
+
+// ParseLogLevel converts a string log level to slog.Level.
+// Supported values: debug, info, warn, error. Defaults to info.
+func ParseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/stdioproxy/process.go
+++ b/stdioproxy/process.go
@@ -1,0 +1,319 @@
+package stdioproxy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ProcessState represents the current state of the subprocess.
+type ProcessState int
+
+const (
+	// StateStopped indicates the process has not been started.
+	StateStopped ProcessState = iota
+	// StateRunning indicates the process is running normally.
+	StateRunning
+	// StateCrashed indicates the process terminated unexpectedly.
+	StateCrashed
+)
+
+func (s ProcessState) String() string {
+	switch s {
+	case StateStopped:
+		return "stopped"
+	case StateRunning:
+		return "running"
+	case StateCrashed:
+		return "crashed"
+	default:
+		return "unknown"
+	}
+}
+
+// ProcessManager manages the lifecycle of a stdio MCP server subprocess.
+// It provides thread-safe access to the MCP client session connected to the subprocess.
+type ProcessManager struct {
+	cmdPath   string
+	cmdArgs   []string
+	env       []string
+	workDir   string
+	transport mcp.Transport // optional pre-configured transport (for testing)
+
+	// Notification handlers
+	toolListChangedHandler      func(context.Context, *mcp.ToolListChangedRequest)
+	promptListChangedHandler    func(context.Context, *mcp.PromptListChangedRequest)
+	resourceListChangedHandler  func(context.Context, *mcp.ResourceListChangedRequest)
+	resourceUpdatedHandler      func(context.Context, *mcp.ResourceUpdatedNotificationRequest)
+	loggingMessageHandler       func(context.Context, *mcp.LoggingMessageRequest)
+	progressNotificationHandler func(context.Context, *mcp.ProgressNotificationClientRequest)
+	createMessageHandler        func(context.Context, *mcp.CreateMessageRequest) (*mcp.CreateMessageResult, error)
+	elicitationHandler          func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)
+
+	mu      sync.RWMutex
+	state   ProcessState
+	err     error
+	session *mcp.ClientSession
+	cmd     *exec.Cmd // nil when using custom transport
+	logger  *slog.Logger
+}
+
+// ProcessManagerConfig holds configuration for creating a ProcessManager.
+type ProcessManagerConfig struct {
+	// Command is the path to the executable.
+	// Ignored if Transport is set.
+	Command string
+	// Args are the command-line arguments.
+	// Ignored if Transport is set.
+	Args []string
+	// Env is optional environment variables (in "KEY=VALUE" format).
+	// If nil, inherits from parent process.
+	// Ignored if Transport is set.
+	Env []string
+	// WorkDir is the working directory for the subprocess.
+	// If empty, inherits from parent process.
+	// Ignored if Transport is set.
+	WorkDir string
+	// Logger for logging process events.
+	Logger *slog.Logger
+
+	// Transport is an optional pre-configured transport.
+	// If set, no subprocess is started and Command/Args/Env/WorkDir are ignored.
+	// This is primarily useful for testing with in-memory transports.
+	Transport mcp.Transport
+
+	// Notification handlers for events from the subprocess.
+	// These are called when the subprocess sends notifications.
+	ToolListChangedHandler      func(context.Context, *mcp.ToolListChangedRequest)
+	PromptListChangedHandler    func(context.Context, *mcp.PromptListChangedRequest)
+	ResourceListChangedHandler  func(context.Context, *mcp.ResourceListChangedRequest)
+	ResourceUpdatedHandler      func(context.Context, *mcp.ResourceUpdatedNotificationRequest)
+	LoggingMessageHandler       func(context.Context, *mcp.LoggingMessageRequest)
+	ProgressNotificationHandler func(context.Context, *mcp.ProgressNotificationClientRequest)
+
+	// Sampling handler - called when subprocess requests LLM completion.
+	// If nil, sampling requests will be rejected with an error.
+	CreateMessageHandler func(context.Context, *mcp.CreateMessageRequest) (*mcp.CreateMessageResult, error)
+
+	// Elicitation handler - called when subprocess requests user input.
+	// If nil, elicitation requests will be rejected with an error.
+	ElicitationHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)
+}
+
+// NewProcessManager creates a new ProcessManager with the given configuration.
+func NewProcessManager(cfg ProcessManagerConfig) *ProcessManager {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &ProcessManager{
+		cmdPath:                     cfg.Command,
+		cmdArgs:                     cfg.Args,
+		env:                         cfg.Env,
+		workDir:                     cfg.WorkDir,
+		transport:                   cfg.Transport,
+		toolListChangedHandler:      cfg.ToolListChangedHandler,
+		promptListChangedHandler:    cfg.PromptListChangedHandler,
+		resourceListChangedHandler:  cfg.ResourceListChangedHandler,
+		resourceUpdatedHandler:      cfg.ResourceUpdatedHandler,
+		loggingMessageHandler:       cfg.LoggingMessageHandler,
+		progressNotificationHandler: cfg.ProgressNotificationHandler,
+		createMessageHandler:        cfg.CreateMessageHandler,
+		elicitationHandler:          cfg.ElicitationHandler,
+		state:                       StateStopped,
+		logger:                      logger,
+	}
+}
+
+// Start spawns the subprocess and establishes an MCP client connection.
+// It returns an error if the subprocess fails to start or the MCP handshake fails.
+// If a custom Transport was provided in the config, no subprocess is started.
+func (pm *ProcessManager) Start(ctx context.Context) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.state == StateRunning {
+		return fmt.Errorf("process already running")
+	}
+
+	// Configure client with notification handlers
+	clientOpts := &mcp.ClientOptions{
+		ToolListChangedHandler:      pm.toolListChangedHandler,
+		PromptListChangedHandler:    pm.promptListChangedHandler,
+		ResourceListChangedHandler:  pm.resourceListChangedHandler,
+		ResourceUpdatedHandler:      pm.resourceUpdatedHandler,
+		LoggingMessageHandler:       pm.loggingMessageHandler,
+		ProgressNotificationHandler: pm.progressNotificationHandler,
+		CreateMessageHandler:        pm.createMessageHandler,
+		ElicitationHandler:          pm.elicitationHandler,
+	}
+
+	client := mcp.NewClient(proxyImplementation, clientOpts)
+
+	var transport mcp.Transport
+	var cmd *exec.Cmd
+
+	if pm.transport != nil {
+		// Use pre-configured transport (for testing)
+		pm.logger.Info("using pre-configured transport")
+		transport = pm.transport
+	} else {
+		// Start subprocess with CommandTransport
+		pm.logger.Info("starting subprocess",
+			"command", pm.cmdPath,
+			"args", pm.cmdArgs,
+		)
+
+		cmd = exec.CommandContext(ctx, pm.cmdPath, pm.cmdArgs...) //nolint:gosec // Command path comes from trusted configuration
+
+		// Set up environment
+		if pm.env != nil {
+			cmd.Env = pm.env
+		} else {
+			cmd.Env = os.Environ()
+		}
+
+		// Set working directory
+		if pm.workDir != "" {
+			cmd.Dir = pm.workDir
+		}
+
+		// Pipe stderr to our stderr for debugging
+		cmd.Stderr = os.Stderr
+
+		transport = &mcp.CommandTransport{
+			Command: cmd,
+		}
+	}
+
+	// Connect to the server (this starts the process if using CommandTransport)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		pm.state = StateCrashed
+		pm.err = fmt.Errorf("failed to connect: %w", err)
+		return pm.err
+	}
+
+	pm.cmd = cmd
+	pm.session = session
+	pm.state = StateRunning
+	pm.err = nil
+
+	// Log PID before starting monitor (while we still hold the lock)
+	if cmd != nil && cmd.Process != nil {
+		pm.logger.Info("subprocess started successfully", "pid", cmd.Process.Pid)
+	} else {
+		pm.logger.Info("connected successfully")
+	}
+
+	// Monitor session in background
+	go pm.monitor()
+
+	return nil
+}
+
+// monitor watches the subprocess and updates state if it crashes.
+func (pm *ProcessManager) monitor() {
+	// Wait for the session to terminate
+	err := pm.session.Wait()
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	// Only update state if we haven't already stopped
+	if pm.state == StateRunning {
+		pm.state = StateCrashed
+		if err != nil {
+			pm.err = fmt.Errorf("subprocess terminated: %w", err)
+		} else {
+			pm.err = fmt.Errorf("subprocess terminated unexpectedly")
+		}
+		pm.logger.Error("subprocess crashed",
+			"error", pm.err,
+		)
+	}
+}
+
+// GetSession returns the MCP client session if the process is running.
+// Returns an error if the process is not running or has crashed.
+func (pm *ProcessManager) GetSession() (*mcp.ClientSession, error) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	switch pm.state {
+	case StateStopped:
+		return nil, fmt.Errorf("subprocess not started")
+	case StateCrashed:
+		return nil, pm.err
+	case StateRunning:
+		return pm.session, nil
+	default:
+		return nil, fmt.Errorf("unknown process state")
+	}
+}
+
+// Stop gracefully stops the subprocess (if any) and closes the session.
+func (pm *ProcessManager) Stop() error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.state != StateRunning {
+		return nil
+	}
+
+	pm.logger.Info("stopping")
+
+	pm.state = StateStopped
+
+	// Close the MCP session
+	if pm.session != nil {
+		err := pm.session.Close()
+		pm.session = nil
+		if err != nil {
+			pm.logger.Warn("error closing session", "error", err)
+		}
+	}
+
+	// If we have a subprocess, ensure it's terminated
+	if pm.cmd != nil && pm.cmd.Process != nil {
+		// Wait briefly for graceful exit, then kill if still running
+		done := make(chan struct{})
+		go func() {
+			_ = pm.cmd.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Process exited cleanly
+		case <-time.After(5 * time.Second):
+			// Force kill
+			pm.logger.Warn("subprocess did not exit gracefully, killing")
+			_ = pm.cmd.Process.Kill()
+			<-done
+		}
+	}
+
+	return nil
+}
+
+// State returns the current state of the subprocess.
+func (pm *ProcessManager) State() ProcessState {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return pm.state
+}
+
+// Error returns the last error that caused the process to crash.
+func (pm *ProcessManager) Error() error {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return pm.err
+}

--- a/stdioproxy/proxy.go
+++ b/stdioproxy/proxy.go
@@ -1,0 +1,438 @@
+package stdioproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// proxyImplementation is the shared MCP implementation info for the proxy.
+var proxyImplementation = &mcp.Implementation{
+	Name:    "stdio-proxy",
+	Version: "1.0.0",
+}
+
+// ProxyStats tracks statistics about proxied requests.
+type ProxyStats struct {
+	RequestCount  atomic.Int64
+	ResponseCount atomic.Int64
+	ErrorCount    atomic.Int64
+}
+
+// ProxyServer creates an MCP server that proxies all requests to a subprocess.
+type ProxyServer struct {
+	pm     *ProcessManager
+	logger *slog.Logger
+	stats  *ProxyStats
+}
+
+// NewProxyServer creates a new ProxyServer that forwards requests to the given ProcessManager.
+func NewProxyServer(pm *ProcessManager, logger *slog.Logger) *ProxyServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ProxyServer{
+		pm:     pm,
+		logger: logger,
+		stats:  &ProxyStats{},
+	}
+}
+
+// Stats returns the current proxy statistics.
+func (ps *ProxyServer) Stats() *ProxyStats {
+	return ps.stats
+}
+
+// BuildMCPServer creates an MCP server configured to proxy requests to the subprocess.
+// It discovers capabilities from the subprocess and registers forwarding handlers.
+func (ps *ProxyServer) BuildMCPServer(ctx context.Context) (*mcp.Server, error) {
+	session, err := ps.pm.GetSession()
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+
+	// Create the proxy MCP server
+	mcpServer := mcp.NewServer(proxyImplementation, nil)
+
+	// Discover and register tools from the subprocess
+	if err := ps.registerTools(ctx, mcpServer, session); err != nil {
+		ps.logger.Warn("failed to register tools", "error", err)
+	}
+
+	// Discover and register prompts from the subprocess
+	if err := ps.registerPrompts(ctx, mcpServer, session); err != nil {
+		ps.logger.Warn("failed to register prompts", "error", err)
+	}
+
+	// Discover and register resources from the subprocess
+	if err := ps.registerResources(ctx, mcpServer, session); err != nil {
+		ps.logger.Warn("failed to register resources", "error", err)
+	}
+
+	// Discover and register resource templates from the subprocess
+	if err := ps.registerResourceTemplates(ctx, mcpServer, session); err != nil {
+		ps.logger.Warn("failed to register resource templates", "error", err)
+	}
+
+	return mcpServer, nil
+}
+
+// registerTools discovers tools from the subprocess and registers forwarding handlers.
+func (ps *ProxyServer) registerTools(ctx context.Context, server *mcp.Server, session *mcp.ClientSession) error {
+	result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		return fmt.Errorf("list tools: %w", err)
+	}
+
+	ps.logger.Info("discovered tools from subprocess", "count", len(result.Tools))
+
+	for _, tool := range result.Tools {
+		// Capture tool for closure
+		t := tool
+		ps.logger.Debug("registering tool", "name", t.Name)
+
+		// Register with the low-level handler since we're forwarding raw requests
+		server.AddTool(t, ps.createToolHandler(t.Name))
+	}
+
+	return nil
+}
+
+// createToolHandler creates a handler that forwards tool calls to the subprocess.
+func (ps *ProxyServer) createToolHandler(toolName string) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		start := time.Now()
+		ps.stats.RequestCount.Add(1)
+
+		ps.logger.Info("proxying tool call",
+			"tool", toolName,
+		)
+
+		// Log request arguments at debug level
+		if ps.logger.Enabled(ctx, slog.LevelDebug) {
+			argsJSON, _ := json.Marshal(req.Params.Arguments)
+			ps.logger.Debug("tool call request", "arguments", string(argsJSON))
+		}
+
+		session, err := ps.pm.GetSession()
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			ps.logger.Error("failed to get session for tool call",
+				"tool", toolName,
+				"error", err,
+			)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("proxy error: %v", err)},
+				},
+				IsError: true,
+			}, nil
+		}
+
+		// Forward the call to the subprocess
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      toolName,
+			Arguments: req.Params.Arguments,
+		})
+
+		duration := time.Since(start)
+
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			ps.logger.Error("tool call failed",
+				"tool", toolName,
+				"duration", duration,
+				"error", err,
+			)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("subprocess error: %v", err)},
+				},
+				IsError: true,
+			}, nil
+		}
+
+		ps.stats.ResponseCount.Add(1)
+
+		ps.logger.Info("tool call completed",
+			"tool", toolName,
+			"duration", duration,
+			"isError", result.IsError,
+		)
+
+		// Log full response at debug level
+		if ps.logger.Enabled(ctx, slog.LevelDebug) {
+			respJSON, _ := json.Marshal(result)
+			ps.logger.Debug("tool call response", "body", string(respJSON))
+		}
+
+		return result, nil
+	}
+}
+
+// registerPrompts discovers prompts from the subprocess and registers forwarding handlers.
+func (ps *ProxyServer) registerPrompts(ctx context.Context, server *mcp.Server, session *mcp.ClientSession) error {
+	result, err := session.ListPrompts(ctx, &mcp.ListPromptsParams{})
+	if err != nil {
+		return fmt.Errorf("list prompts: %w", err)
+	}
+
+	ps.logger.Info("discovered prompts from subprocess", "count", len(result.Prompts))
+
+	for _, prompt := range result.Prompts {
+		p := prompt
+		ps.logger.Debug("registering prompt", "name", p.Name)
+
+		server.AddPrompt(p, ps.createPromptHandler(p.Name))
+	}
+
+	return nil
+}
+
+// createPromptHandler creates a handler that forwards prompt requests to the subprocess.
+func (ps *ProxyServer) createPromptHandler(promptName string) mcp.PromptHandler {
+	return func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		start := time.Now()
+		ps.stats.RequestCount.Add(1)
+
+		ps.logger.Info("proxying prompt request",
+			"prompt", promptName,
+		)
+
+		session, err := ps.pm.GetSession()
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			return nil, fmt.Errorf("get session: %w", err)
+		}
+
+		result, err := session.GetPrompt(ctx, &mcp.GetPromptParams{
+			Name:      promptName,
+			Arguments: req.Params.Arguments,
+		})
+
+		duration := time.Since(start)
+
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			ps.logger.Error("prompt request failed",
+				"prompt", promptName,
+				"duration", duration,
+				"error", err,
+			)
+			return nil, err
+		}
+
+		ps.stats.ResponseCount.Add(1)
+		ps.logger.Info("prompt request completed",
+			"prompt", promptName,
+			"duration", duration,
+		)
+
+		return result, nil
+	}
+}
+
+// registerResources discovers resources from the subprocess and registers forwarding handlers.
+func (ps *ProxyServer) registerResources(ctx context.Context, server *mcp.Server, session *mcp.ClientSession) error {
+	result, err := session.ListResources(ctx, &mcp.ListResourcesParams{})
+	if err != nil {
+		return fmt.Errorf("list resources: %w", err)
+	}
+
+	ps.logger.Info("discovered resources from subprocess", "count", len(result.Resources))
+
+	for _, resource := range result.Resources {
+		r := resource
+		ps.logger.Debug("registering resource", "uri", r.URI)
+
+		server.AddResource(r, ps.createResourceHandler(r.URI))
+	}
+
+	return nil
+}
+
+// createResourceHandler creates a handler that forwards resource requests to the subprocess.
+func (ps *ProxyServer) createResourceHandler(uri string) mcp.ResourceHandler {
+	return func(ctx context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		start := time.Now()
+		ps.stats.RequestCount.Add(1)
+
+		ps.logger.Info("proxying resource request",
+			"uri", uri,
+		)
+
+		session, err := ps.pm.GetSession()
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			return nil, fmt.Errorf("get session: %w", err)
+		}
+
+		result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
+			URI: uri,
+		})
+
+		duration := time.Since(start)
+
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			ps.logger.Error("resource request failed",
+				"uri", uri,
+				"duration", duration,
+				"error", err,
+			)
+			return nil, err
+		}
+
+		ps.stats.ResponseCount.Add(1)
+		ps.logger.Info("resource request completed",
+			"uri", uri,
+			"duration", duration,
+		)
+
+		return result, nil
+	}
+}
+
+// registerResourceTemplates discovers resource templates from the subprocess and registers forwarding handlers.
+func (ps *ProxyServer) registerResourceTemplates(ctx context.Context, server *mcp.Server, session *mcp.ClientSession) error {
+	result, err := session.ListResourceTemplates(ctx, &mcp.ListResourceTemplatesParams{})
+	if err != nil {
+		return fmt.Errorf("list resource templates: %w", err)
+	}
+
+	ps.logger.Info("discovered resource templates from subprocess", "count", len(result.ResourceTemplates))
+
+	for _, tmpl := range result.ResourceTemplates {
+		t := tmpl
+		ps.logger.Debug("registering resource template", "uriTemplate", t.URITemplate)
+
+		server.AddResourceTemplate(t, ps.createResourceTemplateHandler(t.URITemplate))
+	}
+
+	return nil
+}
+
+// createResourceTemplateHandler creates a handler that forwards resource template requests to the subprocess.
+func (ps *ProxyServer) createResourceTemplateHandler(uriTemplate string) mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		start := time.Now()
+		ps.stats.RequestCount.Add(1)
+
+		// The actual URI to read comes from the request
+		uri := req.Params.URI
+
+		ps.logger.Info("proxying resource template request",
+			"template", uriTemplate,
+			"uri", uri,
+		)
+
+		session, err := ps.pm.GetSession()
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			return nil, fmt.Errorf("get session: %w", err)
+		}
+
+		result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
+			URI: uri,
+		})
+
+		duration := time.Since(start)
+
+		if err != nil {
+			ps.stats.ErrorCount.Add(1)
+			ps.logger.Error("resource template request failed",
+				"template", uriTemplate,
+				"uri", uri,
+				"duration", duration,
+				"error", err,
+			)
+			return nil, err
+		}
+
+		ps.stats.ResponseCount.Add(1)
+		ps.logger.Info("resource template request completed",
+			"template", uriTemplate,
+			"uri", uri,
+			"duration", duration,
+		)
+
+		return result, nil
+	}
+}
+
+// HTTPHandler wraps the MCP server in an HTTP handler that checks process health.
+type HTTPHandler struct {
+	pm          *ProcessManager
+	mcpHandler  http.Handler
+	logger      *slog.Logger
+	proxyServer *ProxyServer
+}
+
+// NewHTTPHandler creates an HTTP handler that serves MCP requests.
+// It wraps the StreamableHTTPHandler with health checking and logging.
+func NewHTTPHandler(pm *ProcessManager, proxyServer *ProxyServer, logger *slog.Logger) (*HTTPHandler, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Build the MCP server
+	mcpServer, err := proxyServer.BuildMCPServer(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("build MCP server: %w", err)
+	}
+
+	// Create the streamable HTTP handler
+	mcpHandler := mcp.NewStreamableHTTPHandler(
+		func(_ *http.Request) *mcp.Server {
+			return mcpServer
+		},
+		&mcp.StreamableHTTPOptions{
+			Stateless: true,
+		},
+	)
+
+	return &HTTPHandler{
+		pm:          pm,
+		mcpHandler:  mcpHandler,
+		logger:      logger,
+		proxyServer: proxyServer,
+	}, nil
+}
+
+// ServeHTTP implements http.Handler.
+// It checks if the subprocess is healthy before forwarding requests.
+func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check subprocess health
+	state := h.pm.State()
+	if state != StateRunning {
+		h.logger.Error("subprocess not running",
+			"state", state.String(),
+			"error", h.pm.Error(),
+		)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		errMsg := "subprocess not available"
+		if err := h.pm.Error(); err != nil {
+			errMsg = err.Error()
+		}
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","error":{"code":-32000,"message":%q},"id":null}`, errMsg)
+		return
+	}
+
+	// Log the request
+	h.logger.Info("http request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"remote", r.RemoteAddr,
+	)
+
+	// Forward to the MCP handler
+	h.mcpHandler.ServeHTTP(w, r)
+}

--- a/stdioproxy/stdioproxy_test.go
+++ b/stdioproxy/stdioproxy_test.go
@@ -1,0 +1,438 @@
+package stdioproxy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pomerium/mcp-servers/stdioproxy"
+)
+
+// getFreePort returns an available TCP port.
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	addr, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	defer addr.Close()
+	return addr.Addr().(*net.TCPAddr).Port
+}
+
+// startProxy starts the stdio-proxy with an in-process test server.
+func startProxy(t *testing.T, port int) (cleanup func()) {
+	t.Helper()
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create in-process test server and get transport
+	transport := newTestServer(t)
+
+	// Create ProcessManager with the transport
+	pm := stdioproxy.NewProcessManager(stdioproxy.ProcessManagerConfig{
+		Transport: transport,
+		Logger:    logger,
+	})
+
+	// Start the process manager (connects to in-process server)
+	if err := pm.Start(ctx); err != nil {
+		t.Fatalf("failed to start process manager: %v", err)
+	}
+
+	// Create proxy server
+	proxyServer := stdioproxy.NewProxyServer(pm, logger)
+
+	// Create HTTP handler
+	httpHandler, err := stdioproxy.NewHTTPHandler(pm, proxyServer, logger)
+	if err != nil {
+		pm.Stop()
+		t.Fatalf("failed to create HTTP handler: %v", err)
+	}
+
+	// Start HTTP server
+	server := &http.Server{
+		Addr:    fmt.Sprintf("localhost:%d", port),
+		Handler: httpHandler,
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			// Don't log expected shutdown errors
+		}
+	}()
+
+	// Wait for server to be ready
+	waitForServer(t, port, 5*time.Second)
+
+	return func() {
+		server.Close()
+		pm.Stop()
+	}
+}
+
+// waitForServer waits for the HTTP server to be ready.
+func waitForServer(t *testing.T, port int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			time.Sleep(50 * time.Millisecond)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not become ready within %v", url, timeout)
+}
+
+// mcpRequest sends an MCP JSON-RPC request and returns the response.
+func mcpRequest(t *testing.T, port int, method string, params any) map[string]any {
+	t.Helper()
+
+	reqBody := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+	}
+	if params != nil {
+		reqBody["params"] = params
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%d", port)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	// Parse SSE response if needed
+	respStr := string(respBody)
+	if strings.HasPrefix(strings.TrimSpace(respStr), "event:") || strings.HasPrefix(strings.TrimSpace(respStr), "data:") {
+		var lastData string
+		for _, line := range strings.Split(respStr, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "data:") {
+				lastData = strings.TrimPrefix(line, "data:")
+				lastData = strings.TrimSpace(lastData)
+			}
+		}
+		if lastData != "" {
+			respBody = []byte(lastData)
+		}
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v\nBody: %s", err, string(respBody))
+	}
+
+	return result
+}
+
+func TestStdioProxyToolsList(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	resp := mcpRequest(t, port, "tools/list", nil)
+
+	if errVal, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error: %v", errVal)
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got: %v", resp)
+	}
+
+	tools, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatalf("expected tools array, got: %v", result)
+	}
+
+	// Check we have our test tools
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolMap := tool.(map[string]any)
+		toolNames[toolMap["name"].(string)] = true
+	}
+
+	expectedTools := []string{"echo", "add", "slow", "error", "exit"}
+	for _, name := range expectedTools {
+		if !toolNames[name] {
+			t.Errorf("expected tool %q not found in response", name)
+		}
+	}
+}
+
+func TestStdioProxyToolCall(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	tests := []struct {
+		name     string
+		tool     string
+		args     map[string]any
+		wantText string
+		wantErr  bool
+	}{
+		{
+			name:     "echo tool",
+			tool:     "echo",
+			args:     map[string]any{"message": "Hello, World!"},
+			wantText: "Hello, World!",
+		},
+		{
+			name:     "add tool",
+			tool:     "add",
+			args:     map[string]any{"a": 2, "b": 3},
+			wantText: `"result":5`,
+		},
+		{
+			name:    "error tool",
+			tool:    "error",
+			args:    map[string]any{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mcpRequest(t, port, "tools/call", map[string]any{
+				"name":      tt.tool,
+				"arguments": tt.args,
+			})
+
+			if errVal, ok := resp["error"]; ok {
+				t.Fatalf("unexpected error: %v", errVal)
+			}
+
+			result, ok := resp["result"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected result object, got: %v", resp)
+			}
+
+			isError, _ := result["isError"].(bool)
+			if isError != tt.wantErr {
+				t.Errorf("isError = %v, want %v", isError, tt.wantErr)
+			}
+
+			content, ok := result["content"].([]any)
+			if !ok || len(content) == 0 {
+				t.Fatalf("expected content array, got: %v", result)
+			}
+
+			firstContent := content[0].(map[string]any)
+			text, _ := firstContent["text"].(string)
+
+			if tt.wantText != "" && !strings.Contains(text, tt.wantText) {
+				t.Errorf("response text = %q, want to contain %q", text, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestStdioProxyPromptsList(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	resp := mcpRequest(t, port, "prompts/list", nil)
+
+	if errVal, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error: %v", errVal)
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got: %v", resp)
+	}
+
+	prompts, ok := result["prompts"].([]any)
+	if !ok {
+		t.Fatalf("expected prompts array, got: %v", result)
+	}
+
+	if len(prompts) == 0 {
+		t.Error("expected at least one prompt")
+	}
+
+	// Check for our greeting prompt
+	found := false
+	for _, p := range prompts {
+		prompt := p.(map[string]any)
+		if prompt["name"] == "greeting" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected greeting prompt not found")
+	}
+}
+
+func TestStdioProxyPromptGet(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	resp := mcpRequest(t, port, "prompts/get", map[string]any{
+		"name": "greeting",
+		"arguments": map[string]any{
+			"name": "Test User",
+		},
+	})
+
+	if errVal, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error: %v", errVal)
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got: %v", resp)
+	}
+
+	messages, ok := result["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		t.Fatalf("expected messages array, got: %v", result)
+	}
+
+	msg := messages[0].(map[string]any)
+	content := msg["content"].(map[string]any)
+	text := content["text"].(string)
+
+	if !strings.Contains(text, "Test User") {
+		t.Errorf("expected greeting to contain 'Test User', got: %s", text)
+	}
+}
+
+func TestStdioProxyResourcesList(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	resp := mcpRequest(t, port, "resources/list", nil)
+
+	if errVal, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error: %v", errVal)
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got: %v", resp)
+	}
+
+	resources, ok := result["resources"].([]any)
+	if !ok {
+		t.Fatalf("expected resources array, got: %v", result)
+	}
+
+	if len(resources) == 0 {
+		t.Error("expected at least one resource")
+	}
+}
+
+func TestStdioProxyResourceRead(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	resp := mcpRequest(t, port, "resources/read", map[string]any{
+		"uri": "test://hello",
+	})
+
+	if errVal, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error: %v", errVal)
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got: %v", resp)
+	}
+
+	contents, ok := result["contents"].([]any)
+	if !ok || len(contents) == 0 {
+		t.Fatalf("expected contents array, got: %v", result)
+	}
+
+	content := contents[0].(map[string]any)
+	text := content["text"].(string)
+
+	if !strings.Contains(text, "Hello from test resource") {
+		t.Errorf("expected resource text to contain 'Hello from test resource', got: %s", text)
+	}
+}
+
+func TestStdioProxyConcurrentRequests(t *testing.T) {
+	port := getFreePort(t)
+	cleanup := startProxy(t, port)
+	defer cleanup()
+
+	// Send multiple concurrent requests
+	const numRequests = 10
+	results := make(chan error, numRequests)
+
+	for i := range numRequests {
+		go func(i int) {
+			resp := mcpRequest(t, port, "tools/call", map[string]any{
+				"name":      "echo",
+				"arguments": map[string]any{"message": fmt.Sprintf("request-%d", i)},
+			})
+
+			if _, ok := resp["error"]; ok {
+				results <- fmt.Errorf("request %d failed: %v", i, resp["error"])
+				return
+			}
+
+			result := resp["result"].(map[string]any)
+			content := result["content"].([]any)
+			firstContent := content[0].(map[string]any)
+			text := firstContent["text"].(string)
+
+			expected := fmt.Sprintf("request-%d", i)
+			if text != expected {
+				results <- fmt.Errorf("request %d: got %q, want %q", i, text, expected)
+				return
+			}
+
+			results <- nil
+		}(i)
+	}
+
+	// Collect results
+	for range numRequests {
+		if err := <-results; err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/stdioproxy/testserver_test.go
+++ b/stdioproxy/testserver_test.go
@@ -1,0 +1,159 @@
+package stdioproxy_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newTestServer creates an in-process MCP test server and returns a transport
+// that can be used by ProcessManager to connect to it.
+// The server runs in a goroutine and is automatically stopped when the test completes.
+func newTestServer(t *testing.T) mcp.Transport {
+	t.Helper()
+
+	// Create connected in-memory transports
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	// Create the test server
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+
+	// Echo tool - returns the input message
+	type echoArgs struct {
+		Message string `json:"message" jsonschema:"The message to echo back"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "echo",
+		Description: "Echo a message back",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args echoArgs) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: args.Message},
+			},
+		}, nil, nil
+	})
+
+	// Add tool - adds two numbers
+	type addArgs struct {
+		A int `json:"a" jsonschema:"First number"`
+		B int `json:"b" jsonschema:"Second number"`
+	}
+	type addResult struct {
+		Result int `json:"result"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "add",
+		Description: "Add two numbers",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args addArgs) (*mcp.CallToolResult, addResult, error) {
+		return nil, addResult{Result: args.A + args.B}, nil
+	})
+
+	// Slow tool - for testing timeouts
+	type slowArgs struct {
+		DelayMS int `json:"delay_ms" jsonschema:"Delay in milliseconds before responding"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "slow",
+		Description: "Responds after a delay",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args slowArgs) (*mcp.CallToolResult, any, error) {
+		select {
+		case <-time.After(time.Duration(args.DelayMS) * time.Millisecond):
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "done"},
+				},
+			}, nil, nil
+		case <-ctx.Done():
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "cancelled"},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+	})
+
+	// Error tool - always returns an error
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "error",
+		Description: "Always returns an error",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "intentional error"},
+			},
+			IsError: true,
+		}, nil, nil
+	})
+
+	// Exit tool - for testing, returns an error to simulate failure
+	type exitArgs struct {
+		Code int `json:"code" jsonschema:"Exit code"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "exit",
+		Description: "Simulate server exit (returns error in test mode)",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ exitArgs) (*mcp.CallToolResult, any, error) {
+		// In test mode, we can't actually exit, so return an error
+		return nil, nil, errors.New("simulated exit")
+	})
+
+	// Add a test prompt
+	server.AddPrompt(&mcp.Prompt{
+		Name:        "greeting",
+		Description: "A simple greeting prompt",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "name", Description: "Name to greet", Required: true},
+		},
+	}, func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		name := "World"
+		if n, ok := req.Params.Arguments["name"]; ok && n != "" {
+			name = n
+		}
+		return &mcp.GetPromptResult{
+			Messages: []*mcp.PromptMessage{
+				{
+					Role: "user",
+					Content: &mcp.TextContent{
+						Text: "Hello, " + name + "!",
+					},
+				},
+			},
+		}, nil
+	})
+
+	// Add a test resource
+	server.AddResource(&mcp.Resource{
+		URI:         "test://hello",
+		Name:        "Hello Resource",
+		Description: "A simple test resource",
+		MIMEType:    "text/plain",
+	}, func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{
+				{
+					URI:      "test://hello",
+					MIMEType: "text/plain",
+					Text:     "Hello from test resource!",
+				},
+			},
+		}, nil
+	})
+
+	// Start the server in a goroutine
+	// The server will automatically connect using the serverTransport
+	go func() {
+		_ = server.Run(t.Context(), serverTransport)
+	}()
+
+	return clientTransport
+}


### PR DESCRIPTION
## Summary

- Add new `stdio-proxy` command that launches a stdio MCP server subprocess and exposes it via HTTP streaming
- Subprocess lifecycle management with graceful shutdown and crash detection
- Automatic capability discovery and forwarding (tools, prompts, resources, resource templates)
- Request/response logging with terminal-aware formatting (text for TTY, JSON for daemon)
- Concurrent request handling with shared subprocess model
- Health checking with 503 responses when subprocess unavailable
- Full bidirectional MCP support:
  - Notification handlers (logging, tool/prompt/resource list changes)
  - Sampling/CreateMessage (server can request LLM completions from client)
  - Elicitation (server can request user input from client)

## Test plan

- [x] Unit tests for tools, prompts, resources (7 tests)
- [x] Unit tests for bidirectional features (5 tests):
  - Logging notifications
  - Sampling with and without handler
  - Elicitation with and without handler
- [ ] Manual test with real stdio MCP server
- [ ] Test subprocess crash handling

## Usage

```bash
# Start proxy for a stdio MCP server
mcp-servers stdio-proxy -addr localhost:8080 -- /path/to/stdio-server

# With debug logging
mcp-servers stdio-proxy -addr localhost:8080 -log-level debug -- /path/to/stdio-server
```